### PR TITLE
Sort tree files

### DIFF
--- a/robotframework_libtoc/libtoc.py
+++ b/robotframework_libtoc/libtoc.py
@@ -113,7 +113,7 @@ def add_files_from_folder(folder, base_dir_path, root=True):
         result_str += """<div class="collapsible_content">
         """
 
-    for item in os.listdir(folder):
+    for item in sorted(os.listdir(folder)):
         item_path = os.path.abspath(os.path.join(folder, item))
         if item.endswith(".html"):
             name_without_ext = os.path.splitext(item)[0]


### PR DESCRIPTION
According to the Python documentation of `os.listdir`: https://docs.python.org/3/library/os.html#os.listdir

> Return a list containing the names of the entries in the directory given by path. **The list is in arbitrary order**, and does not include the special entries '.' and '..' even if they are present in the directory. If a file is removed from or added to the directory during the call of this function, whether a name for that file be included is unspecified.

Iterating on `os.listdir` may cause the TOC to be unsorted, and very ugly.

The tree should be sorted on the final ouput, we don't care about the initial process order.

By the way, thanks for the project!